### PR TITLE
fix: client wasn't released on csv import error

### DIFF
--- a/lib/csv-folder-to-db.js
+++ b/lib/csv-folder-to-db.js
@@ -70,19 +70,21 @@ export async function csvFromFolderToDb (connection, path, tablesWithDependencie
 
   const client = await pool.connect();
 
-  for (const file of files) {
-    const name = pathModule.basename(file, '.csv');
-    const dbCopy = client.query(copyFrom(`COPY ${name} FROM STDIN WITH (FORMAT csv, HEADER MATCH)`));
+  try {
+    for (const file of files) {
+      const name = pathModule.basename(file, '.csv');
+      const dbCopy = client.query(copyFrom(`COPY ${name} FROM STDIN WITH (FORMAT csv, HEADER MATCH)`));
 
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    const csvContent = createReadStream(file);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      const csvContent = createReadStream(file);
 
-    try {
-      await promisedPipeline(csvContent, dbCopy);
-    } catch (cause) {
-      throw new Error(`Failed inserting data into "${name}"`, { cause });
+      try {
+        await promisedPipeline(csvContent, dbCopy);
+      } catch (cause) {
+        throw new Error(`Failed inserting data into "${name}"`, { cause });
+      }
     }
+  } finally {
+    client.release();
   }
-
-  client.release();
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,6 @@ import pg from 'pg';
  *
  * @see {@link https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS|PostgreSQL Advisory Lock Functions}
  * @see {@link https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS|Advisory Locks Overview}
-
  */
 const LOCK_ID = 42;
 

--- a/test/integration/csv-folder-to-db.spec.js
+++ b/test/integration/csv-folder-to-db.spec.js
@@ -1,0 +1,67 @@
+import chai from 'chai';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import pathModule from 'node:path';
+import { tmpdir } from 'node:os';
+import { setTimeout as delay } from 'node:timers/promises';
+import { Pool } from 'pg';
+
+import { csvFromFolderToDb } from '../../index.js';
+
+import { connectionString } from '../db.js';
+
+chai.should();
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} timeoutMs
+ * @returns {Promise<T>}
+ */
+async function withTimeout (promise, timeoutMs) {
+  return Promise.race([
+    promise,
+    (async () => {
+      await delay(timeoutMs);
+      throw new Error(`Timed out after ${timeoutMs}ms`);
+    })(),
+  ]);
+}
+
+describe('csvFromFolderToDb integration', () => {
+  it('should release the client when fixture import fails', async function () {
+    this.timeout(5000);
+    const tableName = 'table_that_should_not_exist';
+    const fixturePath = await mkdtemp(pathModule.join(tmpdir(), 'pg-utils-regression-'));
+
+    const pool = new Pool({
+      connectionString,
+      max: 1,
+    });
+
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      await writeFile(
+        pathModule.join(fixturePath, `${tableName}.csv`),
+        'id\n1\n'
+      );
+
+      try {
+        await csvFromFolderToDb(pool, fixturePath);
+        throw new Error('Expected fixture import to fail');
+      } catch (err) {
+        /** @type {Error} */ (err).message.should.equal(`Failed inserting data into "${tableName}"`);
+      }
+
+      pool.totalCount.should.equal(1);
+      pool.idleCount.should.equal(1);
+
+      const { rows } = await withTimeout(pool.query('SELECT 1 AS value'), 1000);
+      rows.should.deep.equal([
+        { value: 1 },
+      ]);
+    } finally {
+      await rm(fixturePath, { recursive: true, force: true });
+      await pool.end();
+    }
+  });
+});


### PR DESCRIPTION
This pull request improves the reliability of the `csvFromFolderToDb` function by ensuring that database clients are always released, even if an error occurs during CSV import. Additionally, it adds an integration test to verify this behavior.

**Resource management improvements:**

* Wrapped the database client usage in a `try...finally` block in `csvFromFolderToDb` to guarantee that the client is released back to the pool regardless of success or failure. [[1]](diffhunk://#diff-a56e26ef3627a0190ec579a34dcd16c748300ee8bc919c08d3b0ffa2674ec102R73) [[2]](diffhunk://#diff-a56e26ef3627a0190ec579a34dcd16c748300ee8bc919c08d3b0ffa2674ec102L86-R90)

**Testing enhancements:**

* Added a new integration test (`csv-folder-to-db.spec.js`) to verify that the client is properly released when a fixture import fails, preventing resource leaks and ensuring the pool remains usable.

**Minor code cleanup:**

* Removed an unnecessary blank line in `lib/utils.js` for code style consistency.