### PR TITLE
fix(deps): widen umzeption range to allow 0.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@voxpelli/typed-utils": "^4.1.0",
     "pg": "^8.18.0",
     "pg-copy-streams": "^7.0.0",
-    "umzeption": "^0.4.1",
+    "umzeption": "^0.4.1 || ^0.5.0",
     "umzug": "^3.8.2"
   }
 }


### PR DESCRIPTION
## What

Widens the `umzeption` dependency range from `^0.4.1` to `^0.4.1 || ^0.5.0` so consumers can use the latest umzeption (0.5.1) alongside `@voxpelli/pg-utils`.

## Why

`^0.4.1` excludes 0.5.x because npm caret ranges on `0.x` versions lock to the minor (`^0.4.1` ≡ `>=0.4.1 <0.5.0`). A downstream project needs latest umzeption and was blocked by this constraint.

## Compatibility

umzeption 0.5 is **API-compatible** with everything pg-utils consumes:
- Runtime: `createUmzeptionPgContext`, `pgInstallSchemaFromString` — unchanged
- Types: `UmzeptionContext`, `FastifyPostgresStyleDb` — unchanged
- The sole breaking change in 0.5.0 drops Node 18 (floor `^20.9.0 || >=21.1.0`); this package already requires `>=22`, so no impact.
- umzeption 0.5's peers (`umzug ^3.8.1`, `pg ^8.11.2`) are satisfied by our `umzug ^3.8.2` / `pg ^8.18.0`.

## Verification

`npm run check` (lint, tsc, knip, type-coverage, installed-check) passes and the full mocha suite — including DB-backed integration tests that exercise the umzeption schema-install path — passes (63 passing) against umzeption 0.5.1.

## Follow-up

Whether `umzeption`/`umzug`/`pg` should move from `dependencies` to `peerDependencies` is deliberately **out of scope** here (this was a quick unblock) and will be considered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)